### PR TITLE
Most devices for PI1

### DIFF
--- a/RPi/GPIO.py
+++ b/RPi/GPIO.py
@@ -24,5 +24,5 @@ def input(pin):
     pass
 
 
-def add_event_detect(pin, condition, callback):
+def add_event_detect(pin, condition, callback, bouncetime=100):
     pass

--- a/RPi/GPIO.py
+++ b/RPi/GPIO.py
@@ -5,6 +5,8 @@ LOW = 1
 HIGH = 2
 IN = 3
 BCM = 4
+RISING = 5
+FALLING = 6
 
 def setmode(a):
     pass
@@ -19,4 +21,8 @@ def output(a, b):
 
 
 def input(a):
+    pass
+
+
+def add_event_detect(pin, condition, callback):
     pass

--- a/RPi/GPIO.py
+++ b/RPi/GPIO.py
@@ -8,19 +8,19 @@ BCM = 4
 RISING = 5
 FALLING = 6
 
-def setmode(a):
+def setmode(mode):
     pass
 
 
-def setup(a, b):
+def setup(pin, kind):
     pass
 
 
-def output(a, b):
+def output(pin, val):
     pass
 
 
-def input(a):
+def input(pin):
     pass
 
 

--- a/actuators/buzzer.py
+++ b/actuators/buzzer.py
@@ -1,0 +1,25 @@
+import time
+import typing
+from RPi import GPIO
+
+
+def buzz(pin: int):
+    GPIO.setup(pin, GPIO.OUT)
+
+    def do_buzz():
+        GPIO.output(pin, GPIO.HIGH)
+
+    def stop_buzz():
+        GPIO.output(pin, GPIO.HIGH)
+
+    return (do_buzz, stop_buzz)
+
+
+def buzz_simulator(pin: int):
+    def do_buzz():
+        print(f"{time.strftime('%H:%M:%S', time.localtime())} Start buzzing on pin {pin}")
+
+    def stop_buzz():
+        print(f"{time.strftime('%H:%M:%S', time.localtime())} Stop buzzing on pin {pin}")
+    
+    return (do_buzz, stop_buzz)

--- a/actuators/buzzer.py
+++ b/actuators/buzzer.py
@@ -10,7 +10,7 @@ def buzz(pin: int):
         GPIO.output(pin, GPIO.HIGH)
 
     def stop_buzz():
-        GPIO.output(pin, GPIO.HIGH)
+        GPIO.output(pin, GPIO.LOW)
 
     return (do_buzz, stop_buzz)
 

--- a/actuators/buzzer.py
+++ b/actuators/buzzer.py
@@ -1,5 +1,5 @@
+import threading
 import time
-import typing
 from RPi import GPIO
 
 
@@ -15,11 +15,13 @@ def buzz(pin: int):
     return (do_buzz, stop_buzz)
 
 
-def buzz_simulator(pin: int):
+def buzz_simulator(pin: int, print_lock: threading.Lock):
     def do_buzz():
-        print(f"{time.strftime('%H:%M:%S', time.localtime())} Start buzzing on pin {pin}")
+        with print_lock:
+            print(f"{time.strftime('%H:%M:%S', time.localtime())} Start buzzing on pin {pin}")
 
     def stop_buzz():
-        print(f"{time.strftime('%H:%M:%S', time.localtime())} Stop buzzing on pin {pin}")
+        with print_lock:
+            print(f"{time.strftime('%H:%M:%S', time.localtime())} Stop buzzing on pin {pin}")
     
     return (do_buzz, stop_buzz)

--- a/actuators/led.py
+++ b/actuators/led.py
@@ -1,0 +1,27 @@
+import threading
+import time
+from RPi import GPIO
+
+
+def light(pin: int):
+    GPIO.setup(pin, GPIO.OUT)
+
+    def turn_on():
+        GPIO.output(pin, GPIO.HIGH)
+
+    def turn_off():
+        GPIO.output(pin, GPIO.LOW)
+
+    return (turn_on, turn_off)
+
+
+def light_simulator(pin: int, print_lock: threading.Lock):
+    def turn_on():
+        with print_lock:
+            print(f"{time.strftime('%H:%M:%S', time.localtime())} Turn on LED on pin {pin}")
+
+    def turn_off():
+        with print_lock:
+            print(f"{time.strftime('%H:%M:%S', time.localtime())} Turn off LED on pin {pin}")
+    
+    return (turn_on, turn_off)

--- a/common.py
+++ b/common.py
@@ -52,6 +52,11 @@ class MyPiEvent():
 
 
     def is_set(self) -> bool:
+        # TODO: If we have only one `threading.Event` in the whole app, then
+        # we could replace `is_set()` with `event.wait()` in all the components.
+        # That would eliminate the need for long polling which would not only
+        # improve the performance, but also make responses instanteneous (as
+        # opposed to having to wait for sleep() to finish first.
         return self.event.is_set()
     
 

--- a/common.py
+++ b/common.py
@@ -4,6 +4,7 @@ import threading
 class MyPiEventType(Enum):
     STOP = 0,
     BUZZ = 1,
+    STOP_BUZZ = 2,
 
 
 class MyPiEvent():
@@ -23,6 +24,7 @@ class MyPiEvent():
     def __init__(self):
         self.type: MyPiEventType = MyPiEventType.STOP
         self.event = threading.Event()
+        self.pin = 0
 
 
     def set(self, type: MyPiEventType):
@@ -43,8 +45,27 @@ class MyPiEvent():
         self.event.set()
 
 
+    def set_buzz_event(self, pin: int, do_buzz: bool):
+        self.type = MyPiEventType.BUZZ if do_buzz else MyPiEventType.STOP_BUZZ
+        self.pin = pin
+        self.event.set()
+
+
     def is_set(self) -> bool:
         return self.event.is_set()
+    
+
+    def consume(self):
+        """
+        Consume the event, thus making it "unset".
+
+        Use this for events that only a single device should respond to, like
+        a buzzer. 
+        Events such as `STOP` should be handled by all threads and therefore
+        should never be "consumed".
+        """
+
+        self.event.clear()
     
 
     def is_set(self, type: MyPiEventType) -> bool:

--- a/common.py
+++ b/common.py
@@ -5,6 +5,8 @@ class MyPiEventType(Enum):
     STOP = 0,
     BUZZ = 1,
     STOP_BUZZ = 2,
+    LED_ON = 3,
+    LED_OFF = 4
 
 
 class MyPiEvent():
@@ -47,6 +49,12 @@ class MyPiEvent():
 
     def set_buzz_event(self, pin: int, do_buzz: bool):
         self.type = MyPiEventType.BUZZ if do_buzz else MyPiEventType.STOP_BUZZ
+        self.pin = pin
+        self.event.set()
+
+
+    def set_led_event(self, pin: int, turn_on: bool):
+        self.type = MyPiEventType.LED_ON if turn_on else MyPiEventType.LED_OFF
         self.pin = pin
         self.event.set()
 

--- a/common.py
+++ b/common.py
@@ -1,0 +1,55 @@
+from enum import Enum
+import threading
+
+class MyPiEventType(Enum):
+    STOP = 0,
+    BUZZ = 1,
+
+
+class MyPiEvent():
+    """
+    Thin adapter for `threading.Event` with custom parameters. There should be
+    at most one instance of this class, and all event-related logic should use
+    that instance.
+
+    Individual threads may query the event type using `type` or `is_set(type)`.
+
+    Other vars are type-related and should be read from only if the appropriate
+    event was set.
+
+    Think of `MyPiEvent` as a C `union`.
+    """
+
+    def __init__(self):
+        self.type: MyPiEventType = MyPiEventType.STOP
+        self.event = threading.Event()
+
+
+    def set(self, type: MyPiEventType):
+        """
+        Set the event to a given type and fire the event.
+
+        See also the higher-level API `set_*` functions for specific event types.  
+        """
+        self.type = type
+        self.event.set()
+
+
+    def set_stop_event(self):
+        """
+        Set the event that stops all threads from running.
+        """
+        self.type = MyPiEventType.STOP
+        self.event.set()
+
+
+    def is_set(self) -> bool:
+        return self.event.is_set()
+    
+
+    def is_set(self, type: MyPiEventType) -> bool:
+        """
+        Shorthand for `event.is_set() and event.type == type`
+        """
+
+        return self.event.is_set() and self.type == type

--- a/components/buzzer.py
+++ b/components/buzzer.py
@@ -8,10 +8,6 @@ from common import MyPiEvent, MyPiEventType
 
 
 def run(config: config.SensorConfig, event: MyPiEvent, print_lock: threading.Lock):
-    """
-    `when_motion` is a callback function invoked whenever motion is detected. It takes no arguments.
-    """
-
     on_buzz, on_stop_buzz = _get_buzzer(config, print_lock)
     while True:
         if event.is_set(MyPiEventType.STOP):

--- a/components/buzzer.py
+++ b/components/buzzer.py
@@ -7,12 +7,12 @@ import threading
 from common import MyPiEvent, MyPiEventType
 
 
-def run(config: config.SensorConfig, event: MyPiEvent, lock: threading.Lock):
+def run(config: config.SensorConfig, event: MyPiEvent, print_lock: threading.Lock):
     """
     `when_motion` is a callback function invoked whenever motion is detected. It takes no arguments.
     """
 
-    on_buzz, on_stop_buzz = _get_buzzer(config)
+    on_buzz, on_stop_buzz = _get_buzzer(config, print_lock)
     while True:
         if event.is_set(MyPiEventType.STOP):
             print('Stopping buzzer loop')
@@ -28,7 +28,7 @@ def run(config: config.SensorConfig, event: MyPiEvent, lock: threading.Lock):
         time.sleep(config.read_interval)
 
 
-def _get_buzzer(config: config.SensorConfig) -> typing.Tuple[typing.Callable, typing.Callable]:
+def _get_buzzer(config: config.SensorConfig, print_lock: threading.Lock) -> typing.Tuple[typing.Callable, typing.Callable]:
     """
     Returns a tuple of 2 functions: on_buzz, on_stop_buzz.
     Each should get called when the buzz/stop buzz event is set.
@@ -37,4 +37,4 @@ def _get_buzzer(config: config.SensorConfig) -> typing.Tuple[typing.Callable, ty
     if not config.simulated:
         return buzzer.buzz(config.pin)
     else:
-        return buzzer.buzz_simulator(config.pin)
+        return buzzer.buzz_simulator(config.pin, print_lock)

--- a/components/buzzer.py
+++ b/components/buzzer.py
@@ -1,0 +1,40 @@
+import typing
+import actuators.buzzer as buzzer
+import functools
+import time
+import config
+import threading
+from common import MyPiEvent, MyPiEventType
+
+
+def run(config: config.SensorConfig, event: MyPiEvent, lock: threading.Lock):
+    """
+    `when_motion` is a callback function invoked whenever motion is detected. It takes no arguments.
+    """
+
+    on_buzz, on_stop_buzz = _get_buzzer(config)
+    while True:
+        if event.is_set(MyPiEventType.STOP):
+            print('Stopping buzzer loop')
+            break
+    
+        if event.is_set(MyPiEventType.BUZZ) and event.pin == config.pin:
+            on_buzz()
+            event.consume()
+        elif event.is_set(MyPiEventType.STOP_BUZZ) and event.pin == config.pin:
+            on_stop_buzz()
+            event.consume()
+
+        time.sleep(config.read_interval)
+
+
+def _get_buzzer(config: config.SensorConfig) -> typing.Tuple[typing.Callable, typing.Callable]:
+    """
+    Returns a tuple of 2 functions: on_buzz, on_stop_buzz.
+    Each should get called when the buzz/stop buzz event is set.
+    """
+
+    if not config.simulated:
+        return buzzer.buzz(config.pin)
+    else:
+        return buzzer.buzz_simulator(config.pin)

--- a/components/dht.py
+++ b/components/dht.py
@@ -4,13 +4,14 @@ import time
 import typing
 import config
 import threading
+from common import MyPiEvent, MyPiEventType
 
 
-def run(config: config.SensorConfig, stop_event: threading.Event, lock: threading.Lock):
+def run(config: config.SensorConfig, event: MyPiEvent, lock: threading.Lock):
     reader = _get_reader(config)
 
     while True:
-        if stop_event.is_set():
+        if event.is_set(MyPiEventType.STOP):
             print('Stopping dht loop')
             break
         reading = reader()
@@ -22,12 +23,7 @@ def _print_reading(reading: dht.DHTReading, config: config.SensorConfig, lock: t
     t = time.localtime()
 
     with lock:
-        print("-" * 25)
-        print(f"Timestamp: {time.strftime('%H:%M:%S', t)}")
-        print(f"Sensor: {config.name}")
-        print(f"Code: {reading.code}")
-        print(f"Humidity: {reading.humidity}%")
-        print(f"Temperature: {reading.temperature}°C")
+        print(f"{time.strftime('%H:%M:%S', t)} {config.name} {reading.humidity}% {reading.temperature}°C")
 
 
 ReaderCallback = typing.Callable[[], dht.DHTReading]

--- a/components/dht.py
+++ b/components/dht.py
@@ -6,38 +6,34 @@ import config
 import threading
 
 
-def start_reader_loop(config: config.SensorConfig, stop_event: threading.Event):
+def run(config: config.SensorConfig, stop_event: threading.Event, lock: threading.Lock):
     reader = _get_appropriate_reader(config)
-    _reader_loop(reader, config, stop_event)
 
-
-def print_reading(reading: dht.DHTReading, config: config.SensorConfig):
-    t = time.localtime()
-    print("="*20)
-    print(f"Timestamp: {time.strftime('%H:%M:%S', t)}")
-    print(f"Sensor: {config.name}")
-    print(f"Code: {reading.code}")
-    print(f"Humidity: {reading.humidity}%")
-    print(f"Temperature: {reading.temperature}°C")
-
-
-ReaderCallback = typing.Callable[[], dht.DHTReading]
-
-
-def _reader_loop(reader: ReaderCallback, config: config.SensorConfig, stop_event: threading.Event):
     while True:
         if stop_event.is_set():
             print('Stopping dht loop')
             break
         reading = reader()
-        print_reading(reading, config)
+        _print_reading(reading, config, lock)
         time.sleep(config.read_interval)
 
 
-# NOTE: Am I doing type shadowing here? The returns of both read_dht_simulated and
-#       _make_reader should be compatible with ReaderCallback, yet if I make
-#       read_dht_simulated return a different type than expected the MyPy static
-#       type checker doesn't complain.
+def _print_reading(reading: dht.DHTReading, config: config.SensorConfig, lock: threading.Lock):
+    t = time.localtime()
+
+    with lock:
+        print("-" * 25)
+        print(f"Timestamp: {time.strftime('%H:%M:%S', t)}")
+        print(f"Sensor: {config.name}")
+        print(f"Code: {reading.code}")
+        print(f"Humidity: {reading.humidity}%")
+        print(f"Temperature: {reading.temperature}°C")
+
+
+ReaderCallback = typing.Callable[[], dht.DHTReading]
+
+
+# TODO: Possible type shadowing?
 def _get_appropriate_reader(config: config.SensorConfig) -> ReaderCallback:
     if not config.simulated:
         return functools.partial(dht.read_dht, pin=config.pin)

--- a/components/dht.py
+++ b/components/dht.py
@@ -7,7 +7,7 @@ import threading
 
 
 def run(config: config.SensorConfig, stop_event: threading.Event, lock: threading.Lock):
-    reader = _get_appropriate_reader(config)
+    reader = _get_reader(config)
 
     while True:
         if stop_event.is_set():
@@ -34,7 +34,7 @@ ReaderCallback = typing.Callable[[], dht.DHTReading]
 
 
 # TODO: Possible type shadowing?
-def _get_appropriate_reader(config: config.SensorConfig) -> ReaderCallback:
+def _get_reader(config: config.SensorConfig) -> ReaderCallback:
     if not config.simulated:
         return functools.partial(dht.read_dht, pin=config.pin)
     else:

--- a/components/led.py
+++ b/components/led.py
@@ -1,0 +1,36 @@
+import typing
+import actuators.led as led
+import functools
+import time
+import config
+import threading
+from common import MyPiEvent, MyPiEventType
+
+
+def run(config: config.SensorConfig, event: MyPiEvent, print_lock: threading.Lock):
+    turn_on, turn_off = _get_led(config, print_lock)
+    while True:
+        if event.is_set(MyPiEventType.STOP):
+            print('Stopping led loop')
+            break
+    
+        if event.is_set(MyPiEventType.LED_ON) and event.pin == config.pin:
+            turn_on()
+            event.consume()
+        elif event.is_set(MyPiEventType.LED_OFF) and event.pin == config.pin:
+            turn_off()
+            event.consume()
+
+        time.sleep(config.read_interval)
+
+
+def _get_led(config: config.SensorConfig, print_lock: threading.Lock) -> typing.Tuple[typing.Callable, typing.Callable]:
+    """
+    Returns a tuple of 2 functions: turn_on, turn_off.
+    Each should get called when the LED turn on/off event is set.
+    """
+
+    if not config.simulated:
+        return led.light(config.pin)
+    else:
+        return led.light_simulator(config.pin, print_lock)

--- a/components/mds.py
+++ b/components/mds.py
@@ -1,0 +1,31 @@
+# MDS = Magnetic Door Sensor i.e. Door Sensor
+
+import typing
+import sensors.mds as mds
+import functools
+import time
+import config
+import threading
+from common import MyPiEvent, MyPiEventType
+
+
+def run(config: config.SensorConfig, event: MyPiEvent, lock: threading.Lock, on_read: typing.Callable):
+    """
+    `on_read` is a callback function invoked whenever door status data is read.
+    It takes 1 argument denoting the state (open/close).
+    """
+
+    reader = _get_reader(config, on_read)
+    while True:
+        if event.is_set(MyPiEventType.STOP):
+            print('Stopping mds loop')
+            break
+        reader()
+        time.sleep(config.read_interval)
+
+
+def _get_reader(config: config.SensorConfig, on_read: typing.Callable):
+    if not config.simulated:
+        return functools.partial(mds.read, pin=config.pin, on_read=on_read)
+    else:
+        return functools.partial(mds.read_simulator, pin=config.pin, on_read=on_read)

--- a/components/pir.py
+++ b/components/pir.py
@@ -1,0 +1,35 @@
+import sensors.pir as pir
+import functools
+import time
+import typing
+import config
+import threading
+
+
+def run(config: config.SensorConfig, stop_event: threading.Event, lock: threading.Lock):
+    reader = _get_reader(config)
+    while True:
+        if stop_event.is_set():
+            print('Stopping pir loop')
+            break
+        reading = reader()
+        _print_reading(reading, config, lock)
+        time.sleep(config.read_interval)
+
+
+def _print_reading(reading: pir.PIRReading, config: config.SensorConfig, lock: threading.Lock):
+    t = time.localtime()
+
+    with lock:
+        print("-" * 25)
+        print(f"Timestamp: {time.strftime('%H:%M:%S', t)}")
+        print(f"Sensor: {config.name}")
+        print(f"Motion: {'YES' if reading.motion else 'NO'}")
+
+
+
+def _get_reader(config: config.SensorConfig):
+    if not config.simulated:
+        return functools.partial(pir.read, pin=config.pin)
+    else:
+        return pir.Simulator().read

--- a/components/pir.py
+++ b/components/pir.py
@@ -1,7 +1,6 @@
 import sensors.pir as pir
 import functools
 import time
-import typing
 import config
 import threading
 

--- a/config.py
+++ b/config.py
@@ -12,4 +12,9 @@ class SensorConfig:
 
 
 def load_configs(path):
-    return [SensorConfig(**x) for x in json.load(open(path))]
+    list_of_dict = json.load(open(path))
+    res = {
+        x['name']: SensorConfig(**x) for x in list_of_dict
+    }
+
+    return res

--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ import dataclasses
 @dataclasses.dataclass
 class SensorConfig:
     name: str
+    type: str
     pin: int
     simulated: bool
     read_interval: float

--- a/data/configs.json
+++ b/data/configs.json
@@ -1,14 +1,30 @@
 [
     {
         "name": "RDHT1",
+        "type": "dht",
         "pin": 17,
         "simulated": true,
         "read_interval": 2.5
     },
     {
         "name": "RDHT2",
+        "type": "dht",
         "pin": 27,
         "simulated": true,
         "read_interval": 2.4
+    },
+    {
+        "name": "RPIR1",
+        "type": "pir",
+        "pin": 22,
+        "simulated": true,
+        "read_interval": 1.0
+    },
+    {
+        "name": "RPIR2",
+        "type": "pir",
+        "pin": 10,
+        "simulated": true,
+        "read_interval": 2.0
     }
 ]

--- a/data/configs.json
+++ b/data/configs.json
@@ -1,8 +1,14 @@
 [
     {
-        "name": "DHT1",
+        "name": "RDHT1",
         "pin": 17,
         "simulated": true,
-        "read_interval": 0.5
+        "read_interval": 2.5
+    },
+    {
+        "name": "RDHT2",
+        "pin": 27,
+        "simulated": true,
+        "read_interval": 2.4
     }
 ]

--- a/data/configs.json
+++ b/data/configs.json
@@ -47,5 +47,12 @@
         "pin": 0,
         "simulated": true,
         "read_interval": 0.5
+    },
+    {
+        "name": "DL",
+        "type": "led",
+        "pin": 5,
+        "simulated": true,
+        "read_interval": 1.5
     }
 ]

--- a/data/configs.json
+++ b/data/configs.json
@@ -33,5 +33,12 @@
         "pin": 9,
         "simulated": true,
         "read_interval": 1.0
+    },
+    {
+        "name": "DPIR1",
+        "type": "pir",
+        "pin": 11,
+        "simulated": true,
+        "read_interval": 3.0
     }
 ]

--- a/data/configs.json
+++ b/data/configs.json
@@ -40,5 +40,12 @@
         "pin": 11,
         "simulated": true,
         "read_interval": 3.0
+    },
+    {
+        "name": "DS1",
+        "type": "mds",
+        "pin": 0,
+        "simulated": true,
+        "read_interval": 0.5
     }
 ]

--- a/data/configs.json
+++ b/data/configs.json
@@ -32,6 +32,6 @@
         "type": "buzzer",
         "pin": 9,
         "simulated": true,
-        "read_interval": 2.0
+        "read_interval": 1.0
     }
 ]

--- a/data/configs.json
+++ b/data/configs.json
@@ -26,5 +26,12 @@
         "pin": 10,
         "simulated": true,
         "read_interval": 2.0
+    },
+    {
+        "name": "DB",
+        "type": "buzzer",
+        "pin": 9,
+        "simulated": true,
+        "read_interval": 2.0
     }
 ]

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import typing
 import RPi.GPIO as GPIO
 from components import dht
 from components import pir
+from components import buzzer
 
 
 class Args(typing.NamedTuple):
@@ -53,6 +54,7 @@ def make_component_loop_threads(configs: dict[str, config.SensorConfig], event: 
     threads.append(make_thread(dht.run, configs['RDHT2'], event, lock))
     threads.append(make_thread(pir.run, configs['RPIR1'], event, lock, rpir1_on_motion))
     threads.append(make_thread(pir.run, configs['RPIR2'], event, lock, rpir2_on_motion))
+    threads.append(make_thread(buzzer.run, configs['DB'], event, lock))
 
     return threads
 
@@ -68,7 +70,15 @@ def main():
     try:
         for thread in threads:
             thread.start()
-        while True:
+
+        time.sleep(5)
+        event.set_buzz_event(configs['DB'].pin, True)
+        time.sleep(5)
+        event.set_buzz_event(configs['DB'].pin, False)
+        time.sleep(1)
+        event.set_buzz_event(configs['DB'].pin, True)
+
+        while True:   
             time.sleep(args.main_loop_sleep)
 
     except KeyboardInterrupt:

--- a/main.py
+++ b/main.py
@@ -23,7 +23,10 @@ def parse_args():
 def make_component_loop_threads(configs: list[config.SensorConfig], stop_event: threading.Event):
     threads: list[threading.Thread] = []
     make_thread = lambda target, *args: threading.Thread(target=target, args=args)
-    threads.append(make_thread(components.dht.start_reader_loop, configs[0], stop_event))
+    lock = threading.Lock()
+
+    threads.append(make_thread(components.dht.run, configs[0], stop_event, lock))
+    threads.append(make_thread(components.dht.run, configs[1], stop_event, lock))
     return threads
 
 

--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ def parse_args():
     return Args(args.configs_path, args.main_loop_sleep)
 
 
-def make_component_loop_threads(configs: dict[str, config.SensorConfig], event: MyPiEvent) -> list[threading.Thread]:
+def make_component_loop_threads(configs: dict[str, config.SensorConfig], event: MyPiEvent, print_lock: threading.Lock) -> list[threading.Thread]:
     '''
     Desc
     ----
@@ -36,54 +36,115 @@ def make_component_loop_threads(configs: dict[str, config.SensorConfig], event: 
     Each thread's runnable is a `run` method for a device component.
     '''
 
-    lock = threading.Lock()
+    
 
     def make_thread(target: typing.Callable, *args):
         return threading.Thread(target=target, args=args)
 
     def rpir1_on_motion():
-        with lock:
+        with print_lock:
             print(f"{time.strftime('%H:%M:%S', time.localtime())} RPIR1 motion")
 
     def rpir2_on_motion():
-        with lock:
+        with print_lock:
             print(f"{time.strftime('%H:%M:%S', time.localtime())} RPIR2 motion")
 
     threads: list[threading.Thread] = []
-    threads.append(make_thread(dht.run, configs['RDHT1'], event, lock))
-    threads.append(make_thread(dht.run, configs['RDHT2'], event, lock))
-    threads.append(make_thread(pir.run, configs['RPIR1'], event, lock, rpir1_on_motion))
-    threads.append(make_thread(pir.run, configs['RPIR2'], event, lock, rpir2_on_motion))
-    threads.append(make_thread(buzzer.run, configs['DB'], event, lock))
+    threads.append(make_thread(dht.run, configs['RDHT1'], event, print_lock))
+    threads.append(make_thread(dht.run, configs['RDHT2'], event, print_lock))
+    threads.append(make_thread(pir.run, configs['RPIR1'], event, print_lock, rpir1_on_motion))
+    threads.append(make_thread(pir.run, configs['RPIR2'], event, print_lock, rpir2_on_motion))
+    threads.append(make_thread(buzzer.run, configs['DB'], event, print_lock))
 
     return threads
 
 
-def main():
-    args = parse_args()
-
-    event = MyPiEvent()
-    configs = config.load_configs(args.configs_path)
-    threads = make_component_loop_threads(configs, event)
-    GPIO.setmode(GPIO.BCM)
-
+def console_app(threads: list, event: MyPiEvent, configs: dict, args: Args, print_lock: threading.Lock):
     try:
         for thread in threads:
             thread.start()
 
-        time.sleep(5)
-        event.set_buzz_event(configs['DB'].pin, True)
-        time.sleep(5)
-        event.set_buzz_event(configs['DB'].pin, False)
-        time.sleep(1)
-        event.set_buzz_event(configs['DB'].pin, True)
+        while True:
+            try:
+                print_lock.release()
+            except:
+                pass
 
-        while True:   
-            time.sleep(args.main_loop_sleep)
+            print_lock.acquire()
+            print("\nSelect command")
+            print('-' * 30)
+            print("listen\t\t(Use keyboard interrupt to return to menu)")
+            print('quit')
+            print("room-buzz-on")
+            print("room-buzz-off")
+            print('-' * 30)
+            print('Enter command:', end='')
+            i = input()
 
+            if i == 'room-buzz-on':
+                event.set_buzz_event(configs['DB'].pin, True)
+            elif i == 'room-buzz-off':
+                event.set_buzz_event(configs['DB'].pin, False)
+            elif i == 'listen':
+                print_lock.release()
+                try:
+                    while True:
+                        time.sleep(args.main_loop_sleep)
+                except KeyboardInterrupt:
+                    print("Stopped listening...")
+            elif i == 'quit':
+                break
+            else:
+                print("Unknown command")
+            
     except KeyboardInterrupt:
+        pass
+    finally:
+        try:
+            print_lock.release()
+        except:
+            pass
         print('Setting stop event...')
         event.set_stop_event()
+
+
+def gui_app(threads: list, event: MyPiEvent, configs: dict, args: Args, print_lock: threading.Lock):
+    err = False
+    try:
+        from guizero import App, Text, PushButton
+
+        def room_buzzer_on():
+            event.set_buzz_event(configs['DB'].pin, True)
+
+        def room_buzzer_off():
+            event.set_buzz_event(configs['DB'].pin, False)
+
+        app = App(title="guizero")
+        PushButton(app, text="Toggle buzzer on", command=room_buzzer_on)
+        PushButton(app, text="Toggle buzzer off", command=room_buzzer_off)
+
+        for thread in threads:
+            thread.start()
+
+        app.display()
+        event.set_stop_event()
+    except Exception:
+        print("Could not start GUI app. Fallback to console app...")
+        err = True
+
+    if err:
+        console_app(threads, event, configs, args, print_lock)
+
+
+def main():
+    args = parse_args()
+    event = MyPiEvent()
+    configs = config.load_configs(args.configs_path)
+    print_lock = threading.Lock()
+    threads = make_component_loop_threads(configs, event, print_lock)
+    GPIO.setmode(GPIO.BCM)
+
+    gui_app(threads, event, configs, args, print_lock)
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import RPi.GPIO as GPIO
 from components import dht
 from components import pir
 from components import buzzer
+from components import mds
 
 
 class Args(typing.NamedTuple):
@@ -53,6 +54,10 @@ def make_component_loop_threads(configs: dict[str, config.SensorConfig], event: 
         with print_lock:
             print(f"{time.strftime('%H:%M:%S', time.localtime())} DPIR1 motion")
 
+    def ds1_on_read(val: int):
+        with print_lock:
+            print(f"{time.strftime('%H:%M:%S', time.localtime())} DS1 {val}")
+
     threads: list[threading.Thread] = []
     threads.append(make_thread(dht.run, configs['RDHT1'], event, print_lock))
     threads.append(make_thread(dht.run, configs['RDHT2'], event, print_lock))
@@ -60,6 +65,7 @@ def make_component_loop_threads(configs: dict[str, config.SensorConfig], event: 
     threads.append(make_thread(pir.run, configs['RPIR2'], event, print_lock, rpir2_on_motion))
     threads.append(make_thread(buzzer.run, configs['DB'], event, print_lock))
     threads.append(make_thread(pir.run, configs['DPIR1'], event, print_lock, dpir1_on_motion))
+    threads.append(make_thread(mds.run, configs['DS1'], event, print_lock, ds1_on_read))
 
     return threads
 
@@ -124,7 +130,7 @@ def gui_app(threads: list, event: MyPiEvent, configs: dict, args: Args, print_lo
         def room_buzzer_off():
             event.set_buzz_event(configs['DB'].pin, False)
 
-        app = App(title="guizero")
+        app = App(title="my pi home gui")
         PushButton(app, text="Toggle buzzer on", command=room_buzzer_on)
         PushButton(app, text="Toggle buzzer off", command=room_buzzer_off)
 

--- a/main.py
+++ b/main.py
@@ -49,12 +49,17 @@ def make_component_loop_threads(configs: dict[str, config.SensorConfig], event: 
         with print_lock:
             print(f"{time.strftime('%H:%M:%S', time.localtime())} RPIR2 motion")
 
+    def dpir1_on_motion():
+        with print_lock:
+            print(f"{time.strftime('%H:%M:%S', time.localtime())} DPIR1 motion")
+
     threads: list[threading.Thread] = []
     threads.append(make_thread(dht.run, configs['RDHT1'], event, print_lock))
     threads.append(make_thread(dht.run, configs['RDHT2'], event, print_lock))
     threads.append(make_thread(pir.run, configs['RPIR1'], event, print_lock, rpir1_on_motion))
     threads.append(make_thread(pir.run, configs['RPIR2'], event, print_lock, rpir2_on_motion))
     threads.append(make_thread(buzzer.run, configs['DB'], event, print_lock))
+    threads.append(make_thread(pir.run, configs['DPIR1'], event, print_lock, dpir1_on_motion))
 
     return threads
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+guizero

--- a/sensors/mds.py
+++ b/sensors/mds.py
@@ -1,0 +1,14 @@
+import typing
+import RPi.GPIO as GPIO
+import random
+
+
+def read(pin: int, on_read: typing.Callable):
+    # Works as a button, but we care about its current state, not the event.
+
+    GPIO.setup(pin, GPIO.IN)
+    on_read(GPIO.input(pin))
+
+
+def read_simulator(pin: int, on_read: typing.Callable):
+    on_read(random.randint(0, 1))

--- a/sensors/pir.py
+++ b/sensors/pir.py
@@ -33,8 +33,8 @@ class Simulator:
 
 
     def read(self) -> PIRReading:
-        if random.randint(0, 5) == 0:
-            if  self.motion:
+        if random.randint(1, 3) == 1:
+            if not self.motion:
                 if self.when_motion is not None:
                     self.when_motion()
                 self.motion = True

--- a/sensors/pir.py
+++ b/sensors/pir.py
@@ -1,46 +1,13 @@
-import RPi.GPIO as GPIO
 import typing
-import time
-import enum
+import RPi.GPIO as GPIO
 import random
 
 
-class PIRReading(typing.NamedTuple):
-    motion: bool
-
-
-def read(pin: int, when_motion = None, when_no_motion = None) -> PIRReading:
+def read(pin: int, when_motion: typing.Callable):
     GPIO.setup(pin, GPIO.IN)
-
-    if when_motion is not None:
-        GPIO.add_event_detect(pin, GPIO.RISING, callback=when_motion)
-    if when_no_motion is not None:
-        GPIO.add_event_detect(pin, GPIO.FALLING, callback=when_no_motion)
-
-    time.sleep(0.5)
-
-    if GPIO.input(pin) == GPIO.HIGH:
-        return PIRReading(True)
-    else:
-        return PIRReading(False)
+    GPIO.add_event_detect(pin, GPIO.RISING, callback=when_motion)
 
 
-class Simulator:
-    def __init__(self, when_motion = None, when_no_motion = None):
-        self.motion = False
-        self.when_motion = when_motion
-        self.when_no_motion = when_no_motion
-
-
-    def read(self) -> PIRReading:
-        if random.randint(1, 3) == 1:
-            if not self.motion:
-                if self.when_motion is not None:
-                    self.when_motion()
-                self.motion = True
-            else:
-                self.motion = False
-                if self.when_no_motion is not None:
-                    self.when_no_motion()
-
-        return PIRReading(self.motion)
+def read_simulator(pin: int, when_motion: typing.Callable):
+    if random.randint(1, 3) == 1:
+        when_motion()

--- a/sensors/pir.py
+++ b/sensors/pir.py
@@ -1,0 +1,46 @@
+import RPi.GPIO as GPIO
+import typing
+import time
+import enum
+import random
+
+
+class PIRReading(typing.NamedTuple):
+    motion: bool
+
+
+def read(pin: int, when_motion = None, when_no_motion = None) -> PIRReading:
+    GPIO.setup(pin, GPIO.IN)
+
+    if when_motion is not None:
+        GPIO.add_event_detect(pin, GPIO.RISING, callback=when_motion)
+    if when_no_motion is not None:
+        GPIO.add_event_detect(pin, GPIO.FALLING, callback=when_no_motion)
+
+    time.sleep(0.5)
+
+    if GPIO.input(pin) == GPIO.HIGH:
+        return PIRReading(True)
+    else:
+        return PIRReading(False)
+
+
+class Simulator:
+    def __init__(self, when_motion = None, when_no_motion = None):
+        self.motion = False
+        self.when_motion = when_motion
+        self.when_no_motion = when_no_motion
+
+
+    def read(self) -> PIRReading:
+        if random.randint(0, 5) == 0:
+            if  self.motion:
+                if self.when_motion is not None:
+                    self.when_motion()
+                self.motion = True
+            else:
+                self.motion = False
+                if self.when_no_motion is not None:
+                    self.when_no_motion()
+
+        return PIRReading(self.motion)


### PR DESCRIPTION
Implemented code for all PI1 devices **except** for:
- `DMS` (Door Membrane Switch)
- `DUS1` (Door Ultrasonic Sensor)

If you want to do those, go ahead. Otherwise, I can do them as well.

---

The simulators I've implemented are functions instead of classes. It's less code and most simulators I wrote don't have state.

I've brought back callbacks, because we'll need them for later (and for doing anything more complicated than printing the sensor state). The callbacks defined in `main.py::make_component_loop_threads(...)` are placeholders.

By the TA's suggestion, I used one large event instead of having more smaller events. Reasons:
1) Less code (wrapper class with handy functions and the event object is the only one that gets passed around instead of having to specify multiple arguments or use a list)
2) Easier to write code for: it's not possible to "wait" for a specific event (like toggling the buzzer) and also to listen for the stop event (unless maybe if we use conditional variables). Long polling is OK for our purposes, as performance isn't an issue (yet?). Therefore, if we're already polling every single event, it's less work when the event object has a clean API.

Caveats:
1) Some events are meant to be "consumed", i.e. cleared once the thread responds to the event. For example: if the `start buzzing on buzzer 1` event is fired, the thread in charge for `buzzer 1` should call `consume()`, or else the thread will respond to the same event again in the next iteration of the while loop. Code-wise inconsistencies aside, we may get concurrency issues: app fires buzz event, buzz thread responds to the event, app fires stop event, buzz thread calls `consume()`, stop event is cleared and effectively ignored (or worse, partially ignored).
2) Since there's only 1 event per thread, we *could* block the thread until the event happens and then respond appropriately, but I'm not sure if this is bug-free, so I kept polling which is less efficient and also not "instantaneous".

---

There's a GUI (again, by TA's suggestion). I used `guizero` which is apparently the go-to GUI for RPi apps. It just has buttons for actuators. That way, the console still prints inputs while the user can play with outputs.

Since I'm not sure how a GUI is going to work without a display on the real thing (after the first checkpoint), I've also added fallback to a console app (in case the gui module could not be imported, the console app starts). Pay attention to how I handle the `print_lock` in the console app. It's ugly but CLI-wise produces the best result.
Notice also that there's a delay between pressing a button and seeing the device thread respond to it. That's because the threads sleep for a bit before continuing. This would be fixed if *caveat 2)* above was solved.