### PR TITLE
Remaining sensors for MQTT/Grafana

### DIFF
--- a/common/app.py
+++ b/common/app.py
@@ -121,8 +121,10 @@ class App:
                         self.invoke_event_funcs(cfg, {"buzz": 0}, "buzz")
                     elif type == MyPiEventType.LED_ON:
                         led.get_turn_on(cfg)()
+                        self.invoke_event_funcs(cfg, {"switch": 1}, "switch")
                     elif type == MyPiEventType.LED_OFF:
                         led.get_turn_off(cfg)()
+                        self.invoke_event_funcs(cfg, {"switch": 0}, "switch")
                     else:
                         raise Exception(f'Unsupported Event type: {type}')
                     

--- a/common/app.py
+++ b/common/app.py
@@ -24,6 +24,7 @@ class App:
         self.print_thread = PrintThread()
         self.event = MyPiEvent()
         self._on_read_funcs = []
+        self._on_event_funcs = {}
 
         self.add_on_read_func(self._log_read)
 
@@ -69,6 +70,20 @@ class App:
         """
 
         self._on_read_funcs.append(f)
+    
+
+    def add_on_event_func(self, type: str, f: typing.Callable):
+        """
+        Desc
+        ---
+
+        Add a function `f(device_cfg: dict, data: dict, event: str) -> None` to a list of
+        functions that get called when the actuator of specified type has an event triggered.
+        """
+        if not self._on_event_funcs.get(type):
+            self._on_event_funcs[type] = [f]
+        else:    
+            self._on_event_funcs[type].append(f)
 
 
     def run(self):
@@ -100,8 +115,10 @@ class App:
                         raise Exception('We should not see the EMPTY event.')
                     if type == MyPiEventType.BUZZ:
                         buzzer.get_do_buzz(cfg)()
+                        self.invoke_event_funcs(cfg, {"buzz": 1}, "buzz")
                     elif type == MyPiEventType.STOP_BUZZ:
                         buzzer.get_stop_buzz(cfg)()
+                        self.invoke_event_funcs(cfg, {"buzz": 0}, "buzz")
                     elif type == MyPiEventType.LED_ON:
                         led.get_turn_on(cfg)()
                     elif type == MyPiEventType.LED_OFF:
@@ -187,6 +204,11 @@ class App:
     def invoke_read_funcs(self, device_cfg: dict, reading: dict):
         for func in self._on_read_funcs:
             func(device_cfg, reading)
+
+
+    def invoke_event_funcs(self, device_cfg: dict, data: dict, event: str):
+        for func in self._on_event_funcs[device_cfg['type']]:
+            func(device_cfg, data, event)
 
 
     def start_device_runners(self):

--- a/components/buzzer.py
+++ b/components/buzzer.py
@@ -1,4 +1,20 @@
 from RPi import GPIO
+from common.mqtt import MqttSender, build_payload
+
+
+class Buzzer_Mqtt(MqttSender):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self.topic = "iot/buzzer"
+
+
+    # Actuactor can have multiple events, so pass the event as well
+    def put(self, cfg: dict, data: dict, event: str):
+        if cfg['type'] != 'buzzer':
+            return
+
+        buzz_payload = build_payload(cfg, data, event)
+        self.do_put(buzz_payload)
 
 
 def get_do_buzz(cfg: dict):

--- a/components/led.py
+++ b/components/led.py
@@ -1,4 +1,20 @@
 from RPi import GPIO
+from common.mqtt import MqttSender, build_payload
+
+
+class LED_Mqtt(MqttSender):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self.topic = "iot/led"
+
+
+    # Actuactor can have multiple events, so pass the event as well
+    def put(self, cfg: dict, data: dict, event: str):
+        if cfg['type'] != 'led':
+            return
+
+        buzz_payload = build_payload(cfg, data, event)
+        self.do_put(buzz_payload)
 
 
 def get_turn_on(cfg: dict):

--- a/components/mbkp.py
+++ b/components/mbkp.py
@@ -1,5 +1,20 @@
 import random
 import RPi.GPIO as GPIO
+from common.mqtt import MqttSender, build_payload
+
+
+class MBKP_Mqtt(MqttSender):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self.topic = "iot/mbkp"
+
+
+    def put(self, cfg: dict, data: dict):
+        if cfg['type'] != 'mbkp':
+            return
+
+        open_payload = build_payload(cfg, data, "keys")
+        self.do_put(open_payload)
 
 
 def get_reader_func(cfg: dict):

--- a/components/mds.py
+++ b/components/mds.py
@@ -1,5 +1,20 @@
 import RPi.GPIO as GPIO
 import random
+from common.mqtt import MqttSender, build_payload
+
+
+class MDS_Mqtt(MqttSender):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self.topic = "iot/mds"
+
+
+    def put(self, cfg: dict, data: dict):
+        if cfg['type'] != 'mds':
+            return
+
+        open_payload = build_payload(cfg, data, "open")
+        self.do_put(open_payload)
 
 
 def get_reader_func(cfg: dict):

--- a/components/uds.py
+++ b/components/uds.py
@@ -1,6 +1,24 @@
 import random
 import RPi.GPIO as GPIO
 import time
+from common.mqtt import MqttSender, build_payload
+
+
+class UDS_Mqtt(MqttSender):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self.topic = "iot/uds"
+
+
+    def put(self, cfg: dict, data: dict):
+        if cfg['type'] != 'uds':
+            return
+
+        distance_payload = build_payload(cfg, data, "distance_in_cm")
+        self.do_put(distance_payload)
+
+        code_payload = build_payload(cfg, data, "code")
+        self.do_put(code_payload)
 
 
 def get_reader_func(cfg: dict):

--- a/grafana/Buzzer.json
+++ b/grafana/Buzzer.json
@@ -1,0 +1,133 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 7,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "influxdb",
+          "uid": "f3699db5-478a-4aab-b472-65e0e3f0b32a"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "influxdb",
+              "uid": "f3699db5-478a-4aab-b472-65e0e3f0b32a"
+            },
+            "query": "from(bucket: \"iotBucket\")\r\n  |> range(start: 0)\r\n  |> filter(fn: (r) => r[\"name\"] == \"DB\")",
+            "refId": "A"
+          }
+        ],
+        "title": "DB",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "2023-12-18T19:02:29.457Z",
+      "to": "2023-12-18T19:04:19.056Z"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Buzzer",
+    "uid": "bbba139c-497d-4053-ab4a-df03cb589de8",
+    "version": 1,
+    "weekStart": ""
+  }

--- a/grafana/LED.json
+++ b/grafana/LED.json
@@ -1,0 +1,133 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 8,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "influxdb",
+          "uid": "f3699db5-478a-4aab-b472-65e0e3f0b32a"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "influxdb",
+              "uid": "f3699db5-478a-4aab-b472-65e0e3f0b32a"
+            },
+            "query": "from(bucket: \"iotBucket\")\r\n  |> range(start: 0)\r\n  |> filter(fn: (r) => r[\"name\"] == \"DL\")",
+            "refId": "A"
+          }
+        ],
+        "title": "DL",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "2023-12-18T19:05:34.582Z",
+      "to": "2023-12-18T19:09:53.622Z"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "LED",
+    "uid": "cda101da-b1da-4cdf-b16c-2d4a04d1d83a",
+    "version": 1,
+    "weekStart": ""
+  }

--- a/grafana/MBKP.json
+++ b/grafana/MBKP.json
@@ -1,0 +1,109 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 6,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "influxdb",
+          "uid": "f3699db5-478a-4aab-b472-65e0e3f0b32a"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true
+        },
+        "pluginVersion": "10.2.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "influxdb",
+              "uid": "f3699db5-478a-4aab-b472-65e0e3f0b32a"
+            },
+            "query": "from(bucket: \"iotBucket\")\r\n  |> range(start: 0)\r\n  |> filter(fn: (r) => r[\"name\"] == \"DMS\")",
+            "refId": "A"
+          }
+        ],
+        "title": "DMS",
+        "type": "table"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "MBKP",
+    "uid": "bf89ea0d-619e-4de7-a13a-176bad3c62a6",
+    "version": 1,
+    "weekStart": ""
+  }

--- a/grafana/MDS.json
+++ b/grafana/MDS.json
@@ -1,0 +1,133 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 5,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "influxdb",
+          "uid": "f3699db5-478a-4aab-b472-65e0e3f0b32a"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "influxdb",
+              "uid": "f3699db5-478a-4aab-b472-65e0e3f0b32a"
+            },
+            "query": "from(bucket: \"iotBucket\")\r\n  |> range(start: 0)\r\n  |> filter(fn: (r) => r[\"name\"] == \"DS1\")",
+            "refId": "A"
+          }
+        ],
+        "title": "DS1",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "MDS",
+    "uid": "f48172bf-2863-4f0c-9463-335addb9bf42",
+    "version": 1,
+    "weekStart": ""
+  }

--- a/grafana/UDS.json
+++ b/grafana/UDS.json
@@ -1,0 +1,133 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 4,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "f3699db5-478a-4aab-b472-65e0e3f0b32a"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "f3699db5-478a-4aab-b472-65e0e3f0b32a"
+          },
+          "query": "from(bucket: \"iotBucket\")\r\n  |> range(start: 0)\r\n  |> filter(fn: (r) => r[\"name\"] == \"DUS1\")",
+          "refId": "A"
+        }
+      ],
+      "title": "DUS1",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "UDS",
+  "uid": "c501920a-ea78-4a7e-ab0e-7df6ea032def",
+  "version": 2,
+  "weekStart": ""
+}

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from components.pir import PIR_Mqtt
 from components.uds import UDS_Mqtt
 from components.mds import MDS_Mqtt
 from components.mbkp import MBKP_Mqtt
+from components.buzzer import Buzzer_Mqtt
 
 
 class Args(typing.NamedTuple):
@@ -35,10 +36,14 @@ def main():
     uds_mqtt = UDS_Mqtt(configs)
     mds_mqtt = MDS_Mqtt(configs)
     mbkp_mqtt = MBKP_Mqtt(configs)
+    buzzer_mqtt = Buzzer_Mqtt(configs)
+
     app.add_on_read_func(dht_mqtt.put)
     app.add_on_read_func(pir_mqtt.put)
     app.add_on_read_func(uds_mqtt.put)
+    app.add_on_read_func(mds_mqtt.put)
     app.add_on_read_func(mbkp_mqtt.put)
+    app.add_on_event_func('buzzer', buzzer_mqtt.put)
     app.run()
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import typing
 from common.app import AppType, App
 from components.dht import DHT_Mqtt
 from components.pir import PIR_Mqtt
+from components.uds import UDS_Mqtt
 
 
 class Args(typing.NamedTuple):
@@ -29,8 +30,10 @@ def main():
 
     dht_mqtt = DHT_Mqtt(configs)
     pir_mqtt = PIR_Mqtt(configs)
+    uds_mqtt = UDS_Mqtt(configs)
     app.add_on_read_func(dht_mqtt.put)
     app.add_on_read_func(pir_mqtt.put)
+    app.add_on_read_func(uds_mqtt.put)
     app.run()
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from common.app import AppType, App
 from components.dht import DHT_Mqtt
 from components.pir import PIR_Mqtt
 from components.uds import UDS_Mqtt
+from components.mds import MDS_Mqtt
 
 
 class Args(typing.NamedTuple):
@@ -31,9 +32,11 @@ def main():
     dht_mqtt = DHT_Mqtt(configs)
     pir_mqtt = PIR_Mqtt(configs)
     uds_mqtt = UDS_Mqtt(configs)
+    mds_mqtt = MDS_Mqtt(configs)
     app.add_on_read_func(dht_mqtt.put)
     app.add_on_read_func(pir_mqtt.put)
     app.add_on_read_func(uds_mqtt.put)
+    app.add_on_read_func(mds_mqtt.put)
     app.run()
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from components.uds import UDS_Mqtt
 from components.mds import MDS_Mqtt
 from components.mbkp import MBKP_Mqtt
 from components.buzzer import Buzzer_Mqtt
+from components.led import LED_Mqtt
 
 
 class Args(typing.NamedTuple):
@@ -37,6 +38,7 @@ def main():
     mds_mqtt = MDS_Mqtt(configs)
     mbkp_mqtt = MBKP_Mqtt(configs)
     buzzer_mqtt = Buzzer_Mqtt(configs)
+    led_mqtt = LED_Mqtt(configs)
 
     app.add_on_read_func(dht_mqtt.put)
     app.add_on_read_func(pir_mqtt.put)
@@ -44,6 +46,7 @@ def main():
     app.add_on_read_func(mds_mqtt.put)
     app.add_on_read_func(mbkp_mqtt.put)
     app.add_on_event_func('buzzer', buzzer_mqtt.put)
+    app.add_on_event_func('led', led_mqtt.put)
     app.run()
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from components.dht import DHT_Mqtt
 from components.pir import PIR_Mqtt
 from components.uds import UDS_Mqtt
 from components.mds import MDS_Mqtt
+from components.mbkp import MBKP_Mqtt
 
 
 class Args(typing.NamedTuple):
@@ -33,10 +34,11 @@ def main():
     pir_mqtt = PIR_Mqtt(configs)
     uds_mqtt = UDS_Mqtt(configs)
     mds_mqtt = MDS_Mqtt(configs)
+    mbkp_mqtt = MBKP_Mqtt(configs)
     app.add_on_read_func(dht_mqtt.put)
     app.add_on_read_func(pir_mqtt.put)
     app.add_on_read_func(uds_mqtt.put)
-    app.add_on_read_func(mds_mqtt.put)
+    app.add_on_read_func(mbkp_mqtt.put)
     app.run()
 
 if __name__ == '__main__':

--- a/server/server.py
+++ b/server/server.py
@@ -17,6 +17,7 @@ def on_connect(client, userdata, flags, rc):
     print("Connected with result code "+str(rc))
     client.subscribe("iot/dht")
     client.subscribe("iot/pir")
+    client.subscribe("iot/uds")
 
 def on_message(client, userdata, msg):
     save_to_db(json.loads(msg.payload.decode('utf-8')))

--- a/server/server.py
+++ b/server/server.py
@@ -21,6 +21,7 @@ def on_connect(client, userdata, flags, rc):
     client.subscribe("iot/mds")
     client.subscribe("iot/mbkp")
     client.subscribe("iot/buzzer")
+    client.subscribe("iot/led")
 
 def on_message(client, userdata, msg):
     save_to_db(json.loads(msg.payload.decode('utf-8')))

--- a/server/server.py
+++ b/server/server.py
@@ -18,6 +18,7 @@ def on_connect(client, userdata, flags, rc):
     client.subscribe("iot/dht")
     client.subscribe("iot/pir")
     client.subscribe("iot/uds")
+    client.subscribe("iot/mds")
 
 def on_message(client, userdata, msg):
     save_to_db(json.loads(msg.payload.decode('utf-8')))

--- a/server/server.py
+++ b/server/server.py
@@ -19,6 +19,7 @@ def on_connect(client, userdata, flags, rc):
     client.subscribe("iot/pir")
     client.subscribe("iot/uds")
     client.subscribe("iot/mds")
+    client.subscribe("iot/mbkp")
 
 def on_message(client, userdata, msg):
     save_to_db(json.loads(msg.payload.decode('utf-8')))

--- a/server/server.py
+++ b/server/server.py
@@ -20,6 +20,7 @@ def on_connect(client, userdata, flags, rc):
     client.subscribe("iot/uds")
     client.subscribe("iot/mds")
     client.subscribe("iot/mbkp")
+    client.subscribe("iot/buzzer")
 
 def on_message(client, userdata, msg):
     save_to_db(json.loads(msg.payload.decode('utf-8')))


### PR DESCRIPTION
~~Didn't make sense to add membrane keypad to MQTT since its data is not numeric.~~ We display the data in a table now.

Added support for actuator-type MQTT senders. The difference here is that an actuator can have several different event types associated with it, so the `put` method also gets passed the name of that event. Technically all of our actuators have only one type of event so this is redundant, but maybe in the future we'll have more complex actuators? I think it makes sense in any case.

`App` now also stores `_on_event_funcs`. This is different from `_on_read_funcs` in that it's a dictionary where the key is the type of device, and the value is a list of all functions to invoke when an event for the given device gets triggered. The funtions get invoked in `start_event_thread`'s `event_func`.